### PR TITLE
feat: custom context support

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -37,8 +37,8 @@ export default function prepare () {
     } = self
 
     if (id) {
-      self.ctx = wx.createCanvasContext(id)
-      self.targetCtx = wx.createCanvasContext(targetId)
+      self.ctx = self.ctx || wx.createCanvasContext(id)
+      self.targetCtx = self.targetCtx || wx.createCanvasContext(targetId)
     } else {
       console.error(`constructor: create canvas context failed, 'id' must be valuable`)
     }


### PR DESCRIPTION
允许通过构造参数传递 canvas 上下文：

```javascript
new WeCropper({
  ctx: wx.createCanvasContext('cropper', this),
  targetCtx: wx.createCanvasContext('targetCropper', this)
})
```

如检测到构造参数有传递 ctx/targetCtx ，则优先使用构造参数传入的 canvas 上下文