### PR TITLE
feat: support componentContext option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -160,6 +160,7 @@
         - original `Boolean` 是否使用原图模式（默认值 `false`） `v1.3.3支持` 
         - quality `Number` 图片的质量，目前仅对 jpg 有效。取值范围为 (0, 1]，不在范围内时当作 1.0 处理。`v1.3.3支持` 
         - fileType `String` 目标文件的类型  `v1.3.3支持` 
+        - componentContext `Object` 在自定义组件下，当前组件实例的this，以操作组件内 <canvas> 组件 `v1.3.4支持`
 
 - callback:
     - Type: `Function`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 ## changelog
 
+### v1.3.4 （2019-04-04）
+
+- `A` 方法 `getCropperImage` 新增参数：`componentContext`（默认值：`false`）
+
 ### v1.3.3 （2019-01-08）
 
 - `A` 方法 `getCropperImage` 新增参数：`original`（默认值：`false`）

--- a/example/app.json
+++ b/example/app.json
@@ -12,7 +12,7 @@
   "window": {
     "backgroundTextStyle": "dark",
     "navigationBarTitleText": "示例",
-    "navigationBarTextStyle": "#fff"
+    "navigationBarTextStyle": "white"
   },
   "networkTimeout": {
     "request": 10000,

--- a/example/avatarUpload/index/index.json
+++ b/example/avatarUpload/index/index.json
@@ -2,5 +2,5 @@
   "backgroundTextStyle": "dark",
   "navigationBarBackgroundColor": "#000",
   "navigationBarTitleText": "设置头像",
-  "navigationBarTextStyle": "#fff"
+  "navigationBarTextStyle": "white"
 }

--- a/example/avatarUpload/upload/upload.json
+++ b/example/avatarUpload/upload/upload.json
@@ -2,5 +2,5 @@
   "backgroundTextStyle":"dark",
   "navigationBarBackgroundColor": "#000",
   "navigationBarTitleText": "裁剪头像",
-  "navigationBarTextStyle":"#fff"
+  "navigationBarTextStyle": "white"
 }

--- a/example/cutInside/cutInside.json
+++ b/example/cutInside/cutInside.json
@@ -2,5 +2,5 @@
   "backgroundTextStyle":"dark",
   "navigationBarBackgroundColor": "#000",
   "navigationBarTitleText": "局部裁剪",
-  "navigationBarTextStyle":"#fff"
+  "navigationBarTextStyle": "white"
 }

--- a/example/network/network.json
+++ b/example/network/network.json
@@ -2,5 +2,5 @@
   "backgroundTextStyle":"dark",
   "navigationBarBackgroundColor": "#000",
   "navigationBarTitleText": "加载网络图",
-  "navigationBarTextStyle":"#fff"
+  "navigationBarTextStyle": "white"
 }

--- a/example/normal/normal.json
+++ b/example/normal/normal.json
@@ -2,5 +2,5 @@
   "backgroundTextStyle":"dark",
   "navigationBarBackgroundColor": "#000",
   "navigationBarTitleText": "常规",
-  "navigationBarTextStyle":"#fff"
+  "navigationBarTextStyle": "white"
 }

--- a/example/setting/setting.json
+++ b/example/setting/setting.json
@@ -2,5 +2,5 @@
     "backgroundTextStyle":"dark",
     "navigationBarBackgroundColor": "#000",
     "navigationBarTitleText": "设置",
-    "navigationBarTextStyle":"#fff"
+    "navigationBarTextStyle": "white"
   }

--- a/example/watermark/watermark.json
+++ b/example/watermark/watermark.json
@@ -2,5 +2,5 @@
   "backgroundTextStyle":"dark",
   "navigationBarBackgroundColor": "#000",
   "navigationBarTitleText": "加水印",
-  "navigationBarTextStyle":"#fff"
+  "navigationBarTextStyle": "white"
 }

--- a/src/methods.js
+++ b/src/methods.js
@@ -97,16 +97,16 @@ export default function methods () {
     }, done)
   }
 
-  self.getCropperImage = (...args) => {
-    const customOptions = args[0]
-    const fn = args[args.length - 1]
+  self.getCropperImage = (opt, fn) => {
+    const customOptions = opt
 
     let canvasOptions = {
       canvasId: id,
       x: x,
       y: y,
       width: width,
-      height: height
+      height: height,
+      componentContext: null
     }
 
     let task = () => Promise.resolve()
@@ -142,7 +142,12 @@ export default function methods () {
         if (isPlainObject(customOptions)) {
           canvasOptions = Object.assign({}, canvasOptions, customOptions)
         }
-        return canvasToTempFilePath(canvasOptions)
+
+        const arg = customOptions.componentContext
+          ? [canvasOptions, customOptions.componentContext]
+          : [canvasOptions]
+
+        return canvasToTempFilePath.apply(null, arg)
       })
       .then(res => {
         const tempFilePath = res.tempFilePath

--- a/src/methods.js
+++ b/src/methods.js
@@ -105,8 +105,7 @@ export default function methods () {
       x: x,
       y: y,
       width: width,
-      height: height,
-      componentContext: null
+      height: height
     }
 
     let task = () => Promise.resolve()

--- a/src/utils/promisify.js
+++ b/src/utils/promisify.js
@@ -1,5 +1,5 @@
 export function wxPromise (fn) {
-  return function (obj = {}) {
+  return function (obj = {}, ...args) {
     return new Promise((resolve, reject) => {
       obj.success = function (res) {
         resolve(res)
@@ -7,7 +7,7 @@ export function wxPromise (fn) {
       obj.fail = function (err) {
         reject(err)
       }
-      fn(obj)
+      fn(obj, ...args)
     })
   }
 }


### PR DESCRIPTION
- getCropperImage

新增 ```componentContext(自定义组件上下文)``` 选项，例：

```javascript
cropper.getCropperImage({
  componentContext: this // 在自定义组件下，当前组件实例的this
}, function (path) {
  console.log('裁剪图片临时路径：', path)
})

```