### PR TITLE
fix: wecropper属性可删除, 在mpvue版中先删除属性再init组件实现改变裁剪框宽高

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -26,7 +26,8 @@ export default function prepare () {
           'this.mycropper.getCropperImage()'
         )
         return self
-      }
+      },
+      configurable: true
     })
   }
 


### PR DESCRIPTION
原we-cropper中wecropper属性不可删除， 初始化时会报redefine的错误。 
修改后，先删除属性， 重新执行init， 可变相实现更改裁剪框宽高。 
```js
// 删除原属性
/* eslint-disable no-undef */
const pages = getCurrentPages()
// 获取到当前page上下文
const pageContext = pages[pages.length - 1]
delete pageContext.wecropper
wecropper.option.cut = {
  x: (width - 300) / 2,
  y: (height - 300) / 2,
  width: 300,
  height: 300
}
wecropper.init()

```